### PR TITLE
Update API usage and switch to audit files

### DIFF
--- a/api-requirements.txt
+++ b/api-requirements.txt
@@ -1,3 +1,3 @@
 -r general-requirements.txt
 requests
--e git+https://github.com/ChameleonCloud/hammers#egg=hammers
+openstacksdk

--- a/general-requirements.txt
+++ b/general-requirements.txt
@@ -1,2 +1,3 @@
 python-dateutil
 configparser
+pandas

--- a/general-requirements.txt
+++ b/general-requirements.txt
@@ -1,3 +1,4 @@
 python-dateutil
 configparser
 pandas
+pyarrow

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+source venv/bin/activate
+
+RCLONE_BUCKET=usage_new_collector
+RCLONE_REMOTE=uc_chameleon
+DATA_DIR=./data
+
+mkdir -p $DATA_DIR
+
+# opts for cloud, data dir, and sync flag
+while getopts "o:d:s" opt; do
+    case $opt in
+        o) OS_CLOUD=$OPTARG;;
+        d) PARQUET_DATA_DIR=$OPTARG;;
+        s) SHOULD_SYNC="true";;
+        ?)
+            echo "Usage: $0 -o <os_cloud> -d <parquet_data_dir> [-s] <action>"
+            echo "action: instance or machine"
+            exit 1
+            ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+ACTION=${1}
+
+# Validate ACTION is present
+if [ -z "$ACTION" ]; then
+    echo "Error: action is required"
+    echo "Usage: $0 -o <os_cloud> -d <parquet_data_dir> [-s] <action>"
+    echo "action: instance or machine"
+    exit 1
+fi
+
+# Validate ACTION is a valid value
+if [ "$ACTION" != "instance" ] && [ "$ACTION" != "machine" ]; then
+    echo "Error: action must be 'instance' or 'machine', got '$ACTION'"
+    echo "Usage: $0 -o <os_cloud> -d <parquet_data_dir> [-s] <action>"
+    echo "action: instance or machine"
+    exit 1
+fi
+
+# Validate required flags
+if [ -z "$PARQUET_DATA_DIR" ]; then
+    echo "Error: -d <parquet_data_dir> is required"
+    echo "Usage: $0 -o <os_cloud> -d <parquet_data_dir> [-s] <action>"
+    echo "action: instance or machine"
+    exit 1
+fi
+
+if [ "$SHOULD_SYNC" = "true" ]; then
+	echo "Syncing data from $RCLONE_REMOTE:$RCLONE_BUCKET to $DATA_DIR"
+	rclone copy $RCLONE_REMOTE:$RCLONE_BUCKET $DATA_DIR
+fi
+
+if [ -n "${PARQUET_DATA_DIR}" ]; then
+	CLOUD_DIR=$(basename $PARQUET_DATA_DIR)
+else
+	CLOUD_DIR=${OS_CLOUD}
+fi
+
+DATESTAMP=$(date +%Y_%m_%d)
+
+OUT_DIR=./chameleon_${CLOUD_DIR}_cloud_trace_${DATESTAMP}
+mkdir -p $OUT_DIR
+
+if [ "$ACTION" = "instance" -a -n "${PARQUET_DATA_DIR}" ]; then
+	echo "Generating instance events for $OS_CLOUD"
+	echo "Storing output in $OUT_DIR"
+	time python -m starcompactor.instance_event_dump \
+		--use-parquet --instance-type baremetal \
+		--parquet-data-dir $PARQUET_DATA_DIR \
+		${OUT_DIR}/${CLOUD_DIR}_instance_events.csv 2>&1 \
+	| tee ${OUT_DIR}/${CLOUD_DIR}_instance_events.log
+
+fi
+
+if [ "$ACTION" = "machine" -a -n "${PARQUET_DATA_DIR}" ]; then
+	echo "Generating machine events for $PARQUET_DATA_DIR"
+	echo "Storing output in $OUT_DIR"
+    time python -m starcompactor.machine_event_dump \
+		--use-parquet --instance-type baremetal \
+		--parquet-data-dir $PARQUET_DATA_DIR \
+		${OUT_DIR}/${CLOUD_DIR}_machine_events.csv 2>&1 \
+	| tee ${OUT_DIR}/${CLOUD_DIR}_machine_events.log
+fi
+

--- a/run.sh
+++ b/run.sh
@@ -2,9 +2,11 @@
 
 source venv/bin/activate
 
+SALT_VALUE="chameleon"
 RCLONE_BUCKET=usage_new_collector
 RCLONE_REMOTE=uc_chameleon
 DATA_DIR=./data
+DATESTAMP=$(date +%Y_%m_%d)
 
 mkdir -p $DATA_DIR
 
@@ -16,7 +18,7 @@ while getopts "o:d:s" opt; do
         s) SHOULD_SYNC="true";;
         ?)
             echo "Usage: $0 -o <os_cloud> -d <parquet_data_dir> [-s] <action>"
-            echo "action: instance or machine"
+            echo "action: instance, machine, or sync"
             exit 1
             ;;
     esac
@@ -29,27 +31,27 @@ ACTION=${1}
 if [ -z "$ACTION" ]; then
     echo "Error: action is required"
     echo "Usage: $0 -o <os_cloud> -d <parquet_data_dir> [-s] <action>"
-    echo "action: instance or machine"
+    echo "action: instance, machine, or sync"
     exit 1
 fi
 
 # Validate ACTION is a valid value
-if [ "$ACTION" != "instance" ] && [ "$ACTION" != "machine" ]; then
-    echo "Error: action must be 'instance' or 'machine', got '$ACTION'"
+if [ "$ACTION" != "instance" ] && [ "$ACTION" != "machine" ] && [ "$ACTION" != "sync" ]; then
+    echo "Error: action must be 'instance', 'machine', or 'sync', got '$ACTION'"
     echo "Usage: $0 -o <os_cloud> -d <parquet_data_dir> [-s] <action>"
-    echo "action: instance or machine"
+    echo "action: instance, machine, or sync"
     exit 1
 fi
 
 # Validate required flags
-if [ -z "$PARQUET_DATA_DIR" ]; then
+if [ -z "$PARQUET_DATA_DIR" -a "$ACTION" != "sync" ]; then
     echo "Error: -d <parquet_data_dir> is required"
     echo "Usage: $0 -o <os_cloud> -d <parquet_data_dir> [-s] <action>"
-    echo "action: instance or machine"
+    echo "action: instance, machine, or sync"
     exit 1
 fi
 
-if [ "$SHOULD_SYNC" = "true" ]; then
+if [ "$SHOULD_SYNC" = "true" -o "$ACTION" = "sync" ]; then
 	echo "Syncing data from $RCLONE_REMOTE:$RCLONE_BUCKET to $DATA_DIR"
 	rclone copy $RCLONE_REMOTE:$RCLONE_BUCKET $DATA_DIR
 fi
@@ -60,28 +62,28 @@ else
 	CLOUD_DIR=${OS_CLOUD}
 fi
 
-DATESTAMP=$(date +%Y_%m_%d)
-
 OUT_DIR=./chameleon_${CLOUD_DIR}_cloud_trace_${DATESTAMP}
-mkdir -p $OUT_DIR
 
 if [ "$ACTION" = "instance" -a -n "${PARQUET_DATA_DIR}" ]; then
+	mkdir -p $OUT_DIR
 	echo "Generating instance events for $OS_CLOUD"
 	echo "Storing output in $OUT_DIR"
 	time python -m starcompactor.instance_event_dump \
 		--use-parquet --instance-type baremetal \
 		--parquet-data-dir $PARQUET_DATA_DIR \
+        --hashed-masking-salt $SALT_VALUE \
 		${OUT_DIR}/${CLOUD_DIR}_instance_events.csv 2>&1 \
 	| tee ${OUT_DIR}/${CLOUD_DIR}_instance_events.log
-
 fi
 
 if [ "$ACTION" = "machine" -a -n "${PARQUET_DATA_DIR}" ]; then
+	mkdir -p $OUT_DIR
 	echo "Generating machine events for $PARQUET_DATA_DIR"
 	echo "Storing output in $OUT_DIR"
     time python -m starcompactor.machine_event_dump \
 		--use-parquet --instance-type baremetal \
 		--parquet-data-dir $PARQUET_DATA_DIR \
+        --hashed-masking-salt $SALT_VALUE \
 		${OUT_DIR}/${CLOUD_DIR}_machine_events.csv 2>&1 \
 	| tee ${OUT_DIR}/${CLOUD_DIR}_machine_events.log
 fi

--- a/starcompactor/extractors/http.py
+++ b/starcompactor/extractors/http.py
@@ -3,7 +3,6 @@ import functools
 import logging
 
 from dateutil.parser import parse as _dateparse
-import requests
 
 LOG = logging.getLogger(__name__)
 OS_ENV_PREFIX = 'OS_'
@@ -14,162 +13,56 @@ def dateparse(value):
         return None
     return _dateparse(value)
 
-def _instances(auth, limit=100, marker=None, deleted=False):
+def all_instances(auth, include_deleted=True):
     '''
-    Get one page of instances
-
-    .. seealso::
-
-        `OpenStack Compute API Reference <https://developer.openstack.org/api-ref/compute/#list-servers-detailed>`_
+    Iterate over all instances ever.
     '''
-    params = {
-        'all_tenants': True,
-    }
-    if deleted:
-        # If you send "deleted=False" or "deleted=0" to the API, it
-        # interprets that as True.
-        params['deleted'] = 1
-    if limit:
-        params['limit'] = limit
-    if marker:
-        params['marker'] = marker
-
-    LOG.info('GET /servers/detail, params: {}'.format(params))
-    response = requests.get(
-        auth.endpoint('compute') + '/servers/detail',
-        headers={
-            'X-Auth-Token': auth.token,
-        },
-        params=params,
-    )
-    response.raise_for_status()
-    return response.json()['servers']
-
-
-def all_instances(auth, include_deleted=True, _pagesize=PAGE_SIZE):
-    '''
-    Iterate over all instances ever. Only requests a page (*_pagesize*)
-    at a time to avoid large/unbounded memory use and possible problems with
-    the HTTP API.
-    '''
-    # Deleted/non-deleted instances are iterated over separately because
-    # "deleted = True" means show *only* deleted instances, not *both* deleted
-    # and undeleted instances.
     if include_deleted:
-        deleted_states = [True, False]
+        yield from auth.compute.servers(all_projects=True, deleted=1)
+        yield from auth.compute.servers(all_projects=True, deleted=0)
     else:
-        deleted_states = [False]
-
-    for deleted_state in deleted_states:
-        _instancesp = functools.partial(_instances, auth, limit=_pagesize, deleted=deleted_state)
-        insts = _instancesp()
-        while True:
-            for inst in insts:
-                LOG.debug(inst)
-                yield inst
-            insts = _instancesp(marker=inst['id'])
-            if len(insts) == 0:
-                break
+        yield from auth.compute.servers(all_projects=True, deleted=0)
 
 def instance_actions(auth, server_id):
     '''
     Get the rough list of actions. As per the API reference: action details
     of deleted instances can be returned for requests later than
     microversion 2.21.
-
-    .. seealso::
-
-        `OpenStack Compute API Reference <https://developer.openstack.org/api-ref/compute/#list-actions-for-server>`_
     '''
-    LOG.info('GET /servers/{}/os-instance-actions'.format(server_id))
-    response = requests.get(
-        auth.endpoint('compute') + '/servers/{}/os-instance-actions'.format(server_id),
-        headers={
-            'X-Auth-Token': auth.token,
-            # must specify API microversion to see a deleted server's actions
-            'X-OpenStack-Nova-API-Version': '2.21',
-        },
-    )
-    response.raise_for_status()
-    return response.json()['instanceActions']
+    # LOG.info(f'Fetching actions for server {server_id}')
+    return list(auth.compute.server_actions(server_id))
 
 
 def instance_action_details(auth, server_id, request_id):
     '''
-    Get details for the action. This is required to split up an action into
-    individual events (like scheduling vs. executing?), and also for the
-    following field data:
-
-    * finish_time
-    * result (does this correlate with message that the actions list already has?)
-
-    .. seealso::
-
-        `OpenStack Compute API Reference <https://developer.openstack.org/api-ref/compute/#show-server-action-details>`_
+    Get details for the action.
     '''
-    LOG.info('GET /servers/{}/os-instance-actions/{}'.format(server_id, request_id))
-    response = requests.get(
-        auth.endpoint('compute') + '/servers/{}/os-instance-actions/{}'.format(server_id, request_id),
-        headers={
-            'X-Auth-Token': auth.token,
-            'X-OpenStack-Nova-API-Version': '2.21',
-        },
+    # The compute SDK doesn't natively expose action detail fetch in generator form 
+    # as easily, but we can call it explicitly using the internal SDK method if it exists,
+    # or fallback to `.get()` 
+    response = auth.compute.get(
+        f'/servers/{server_id}/os-instance-actions/{request_id}',
+        microversion='2.21',
     )
-    response.raise_for_status()
     return response.json()['instanceAction']
-
-
-_flavor_cache = {}
-#@functools.lru_cache() # Py3.2+
-def nova_flavor(auth, flavor_id):
-    '''
-    Gets information about the Nova flavor so it can be attached to the
-    trace event row.
-
-    .. note::
-
-        All events for a given instance will always have the same
-        CPUs/RAM/disk.
-
-    Newer (2.47?) Nova APIs will do this little request internally when
-    getting the instance details. By memoizing this, it should drastically
-    reduce the overall number of requests. There's no bound on the cache,
-    but hopefully the number of flavors is less than 1000.
-    '''
-    # <py2 memoize hack>
-    global _flavor_cache
-    try:
-        return _flavor_cache[flavor_id]
-    except KeyError:
-        pass
-    # </py2 memoize hack>
-    LOG.info('GET /flavors/{}'.format(flavor_id))
-    response = requests.get(
-        auth.endpoint('compute') + '/flavors/{}'.format(flavor_id),
-        headers={
-            'X-Auth-Token': auth.token,
-            'X-OpenStack-Nova-API-Version': '2.21',
-        },
-    )
-    response.raise_for_status()
-
-    flavor = response.json()['flavor']
-    # <py2 memoize hack>
-    _flavor_cache[flavor_id] = flavor
-    # </py2 memoize hack>
-    return flavor
 
 
 def traces_raw(auth):
     '''Yield instance/action/event data in all combinations.'''
-    for instance in all_instances(auth):
-        actions = instance_actions(auth, instance['id'])
+    instances = all_instances(auth)
+    LOG.info('Starting trace extraction...')
+
+    for count, instance in enumerate(instances):
+        if count % 25 == 0 and count > 0:
+            LOG.info(f'Processed {count} instances...')
+
+        actions = instance_actions(auth, instance.id)
         if not actions:
-            LOG.info('instance {} has no actions'.format(instance['id']))
+            LOG.info('instance {} has no actions'.format(instance.id))
             continue
 
         for action in actions:
-            details = instance_action_details(auth, instance['id'], action['request_id'])
+            details = instance_action_details(auth, instance.id, action.request_id)
             for event in details['events']:
                 yield instance, action, event
 
@@ -177,19 +70,18 @@ def traces_raw(auth):
 def traces(auth):
     '''Extract the desired fields from the instance/action/event combos.'''
     for instance, action, event in traces_raw(auth):
-        flavor = nova_flavor(auth, instance['flavor']['id'])
         if event['finish_time'] is None:
             LOG.debug('Invalid event %s', event)
         else:
             yield {
-                'INSTANCE_UUID': instance['id'],
-                'vcpus': flavor['vcpus'],
-                'memory_mb': flavor['ram'],
-                'root_gb': flavor['disk'],
-                'USER_ID': instance['user_id'],
-                'PROJECT_ID': instance['tenant_id'],
-                'INSTANCE_NAME': instance['name'],
-                'HOST_NAME (PHYSICAL)': instance['OS-EXT-SRV-ATTR:host'],
+                'INSTANCE_UUID': instance.id,
+                'vcpus': instance.flavor.vcpus,
+                'memory_mb': instance.flavor.ram,
+                'root_gb': instance.flavor.disk,
+                'USER_ID': instance.user_id,
+                'PROJECT_ID': instance.project_id,
+                'INSTANCE_NAME': instance.name,
+                'HOST_NAME (PHYSICAL)': instance.host,
                 'EVENT': event['event'],
                 'RESULT': event['result'],
                 'START_TIME': dateparse(event['start_time']),

--- a/starcompactor/extractors/http.py
+++ b/starcompactor/extractors/http.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-import functools
 import logging
 
 from dateutil.parser import parse as _dateparse
@@ -13,15 +12,71 @@ def dateparse(value):
         return None
     return _dateparse(value)
 
+
+def _paginate_servers(auth, **kwargs):
+    '''
+    Manually paginate servers(). When a page fetch fails because the marker
+    instance is permanently broken (e.g. Nova 500 InstanceNotFound), skip
+    that marker and try the next UUID from the previous page.  If every
+    candidate in the page is broken, stop pagination for this query.
+    '''
+    marker = None
+    last_page_ids = []
+
+    while True:
+        params = dict(kwargs, limit=PAGE_SIZE)
+        if marker:
+            params['marker'] = marker
+
+        try:
+            page = list(auth.compute.servers(**params))
+        except Exception as e:
+            LOG.warning(f'Failed to fetch page at marker {marker}: {e}')
+
+            # Walk forward through the previous page's UUIDs to find one that works
+            try:
+                start = last_page_ids.index(marker) + 1
+            except ValueError:
+                LOG.error('Cannot advance past broken marker %s; stopping.', marker)
+                return
+
+            advanced = False
+            for candidate in last_page_ids[start:]:
+                try:
+                    page = list(auth.compute.servers(**dict(params, marker=candidate)))
+                    LOG.warning('Skipped broken marker %s, resumed at %s', marker, candidate)
+                    marker = candidate
+                    advanced = True
+                    break
+                except Exception:
+                    continue
+
+            if not advanced:
+                LOG.error('All candidates after broken marker %s failed; stopping.', marker)
+                return
+
+        if not page:
+            break
+
+        last_page_ids = [s.id for s in page]
+        yield from page
+
+        if len(page) < PAGE_SIZE:
+            break
+
+        marker = last_page_ids[-1]
+
+
 def all_instances(auth, include_deleted=True):
     '''
     Iterate over all instances ever.
     '''
     if include_deleted:
-        yield from auth.compute.servers(all_projects=True, deleted=1)
-        yield from auth.compute.servers(all_projects=True, deleted=0)
+        yield from _paginate_servers(auth, all_projects=True, deleted=1)
+        yield from _paginate_servers(auth, all_projects=True, deleted=0)
     else:
-        yield from auth.compute.servers(all_projects=True, deleted=0)
+        yield from _paginate_servers(auth, all_projects=True, deleted=0)
+
 
 def instance_actions(auth, server_id):
     '''
@@ -29,7 +84,6 @@ def instance_actions(auth, server_id):
     of deleted instances can be returned for requests later than
     microversion 2.21.
     '''
-    # LOG.info(f'Fetching actions for server {server_id}')
     return list(auth.compute.server_actions(server_id))
 
 
@@ -37,9 +91,6 @@ def instance_action_details(auth, server_id, request_id):
     '''
     Get details for the action.
     '''
-    # The compute SDK doesn't natively expose action detail fetch in generator form 
-    # as easily, but we can call it explicitly using the internal SDK method if it exists,
-    # or fallback to `.get()` 
     response = auth.compute.get(
         f'/servers/{server_id}/os-instance-actions/{request_id}',
         microversion='2.21',
@@ -49,20 +100,38 @@ def instance_action_details(auth, server_id, request_id):
 
 def traces_raw(auth):
     '''Yield instance/action/event data in all combinations.'''
-    instances = all_instances(auth)
+    instances = list(all_instances(auth))
     LOG.info('Starting trace extraction...')
 
     for count, instance in enumerate(instances):
         if count % 25 == 0 and count > 0:
             LOG.info(f'Processed {count} instances...')
 
-        actions = instance_actions(auth, instance.id)
+        for attempt in range(3):
+            try:
+                actions = instance_actions(auth, instance.id)
+                break
+            except Exception as e:
+                LOG.warning(f'Attempt {attempt + 1}/3 failed fetching actions for {instance.id}: {e}')
+        else:
+            LOG.error(f'Skipping instance {instance.id} after 3 failed attempts')
+            continue
+
         if not actions:
             LOG.info('instance {} has no actions'.format(instance.id))
             continue
 
         for action in actions:
-            details = instance_action_details(auth, instance.id, action.request_id)
+            for attempt in range(3):
+                try:
+                    details = instance_action_details(auth, instance.id, action.request_id)
+                    break
+                except Exception as e:
+                    LOG.warning(f'Attempt {attempt + 1}/3 failed fetching action details for {instance.id}/{action.request_id}: {e}')
+            else:
+                LOG.error(f'Skipping action {action.request_id} for instance {instance.id} after 3 failed attempts')
+                continue
+
             for event in details['events']:
                 yield instance, action, event
 

--- a/starcompactor/extractors/http.py
+++ b/starcompactor/extractors/http.py
@@ -81,7 +81,7 @@ def traces(auth):
                 'USER_ID': instance.user_id,
                 'PROJECT_ID': instance.project_id,
                 'INSTANCE_NAME': instance.name,
-                'HOST_NAME (PHYSICAL)': instance.host,
+                'HOST_NAME (PHYSICAL)': instance.hypervisor_hostname,
                 'EVENT': event['event'],
                 'RESULT': event['result'],
                 'START_TIME': dateparse(event['start_time']),

--- a/starcompactor/extractors/instance.py
+++ b/starcompactor/extractors/instance.py
@@ -52,7 +52,7 @@ def _to_dt(val):
     return dt.replace(tzinfo=None) if dt.tzinfo is not None else dt
 
 
-def get_instance_events_from_parquet(data_dir, start=None, end=None):
+def get_instance_events_from_parquet(data_dir, start=None, end=None, instance_type=None):
     """Read instance action events from openstack_audit parquet files and yield trace dicts.
 
     Replicates the SQL JOIN:
@@ -71,6 +71,8 @@ def get_instance_events_from_parquet(data_dir, start=None, end=None):
         Optional lower bound on ia.created_at (action start time).
     end : datetime or None
         Optional upper bound on ia.created_at (action start time).
+    instance_type : str or None
+        Optional type of instance (e.g. 'baremetal') to determine host selection.
 
     Yields
     ------
@@ -118,7 +120,7 @@ def get_instance_events_from_parquet(data_dir, start=None, end=None):
 
     # Keep only columns we need to reduce memory usage
     instance_cols = ['uuid', 'memory_mb', 'root_gb', 'vcpus',
-                     'user_id', 'project_id', 'hostname', 'host']
+                     'user_id', 'project_id', 'hostname', 'host', 'node']
     df_instances = df_instances[[c for c in instance_cols if c in df_instances.columns]]
 
     # Deduplicate instances by uuid — keep the first INSERT per uuid
@@ -139,7 +141,7 @@ def get_instance_events_from_parquet(data_dir, start=None, end=None):
     # Deduplicate actions by id
     df_actions = df_actions.drop_duplicates(subset=['id'], keep='first')
 
-    event_cols = ['action_id', 'event', 'start_time', 'finish_time', 'result']
+    event_cols = ['action_id', 'event', 'start_time', 'finish_time', 'result', 'host']
     df_events = df_events[[c for c in event_cols if c in df_events.columns]]
 
     # JOIN: instances <-> instance_actions on uuid = instance_uuid
@@ -178,6 +180,25 @@ def get_instance_events_from_parquet(data_dir, start=None, end=None):
             n_skipped += 1
             continue
 
+        host_event = row.get('host_event')
+        host_instance = row.get('host')
+        if pd.isnull(host_event):
+            host_event = None
+        if pd.isnull(host_instance):
+            host_instance = None
+
+        if instance_type == 'baremetal':
+            node_instance = row.get('node')
+            if pd.isnull(node_instance):
+                node_instance = None
+            final_host = node_instance or host_event or host_instance
+        else:
+            final_host = host_event or host_instance
+
+        # print(f"final_host: {final_host}, host_event: {host_event}, host_instance: {host_instance}, node_instance: {node_instance}")
+        if not final_host:
+            LOG.debug('Missing host for event: %s', row.to_dict())
+
         trace = {
             'INSTANCE_UUID':        row.get('uuid'),
             'EVENT':                row.get('event'),
@@ -187,7 +208,7 @@ def get_instance_events_from_parquet(data_dir, start=None, end=None):
             'INSTANCE_NAME':        row.get('hostname'),
             'USER_ID':              row.get('user_id'),
             'PROJECT_ID':           row.get('project_id'),
-            'HOST_NAME (PHYSICAL)': row.get('host'),
+            'HOST_NAME (PHYSICAL)': final_host,
             # Extra instance fields preserved by the original SQL extractor
             'memory_mb':            row.get('memory_mb'),
             'root_gb':              row.get('root_gb'),

--- a/starcompactor/extractors/instance.py
+++ b/starcompactor/extractors/instance.py
@@ -1,0 +1,199 @@
+# coding: utf-8
+"""Extractor for instance action events from openstack_audit parquet files.
+
+Produces trace dicts compatible with the existing mysql.TRACE_EVENT_KEY_RENAME_MAP
+field names so they can flow through the same transform pipeline.
+
+The audit parquet files wrap each row's payload as a JSON string in a 'data'
+column, identical to the machine event audit files.  The relevant tables are:
+  openstack_audit.audit_nova_instances.parquet
+  openstack_audit.audit_nova_instance_actions.parquet
+  openstack_audit.audit_nova_instance_actions_events.parquet
+"""
+import json
+import logging
+import os
+
+import pandas as pd
+from dateutil.parser import parse as dateparse
+
+LOG = logging.getLogger(__name__)
+
+
+def _parse_audit_parquet(path):
+    """Read an audit parquet file, parse JSON payloads, and return a DataFrame.
+
+    Each audit row's 'data' column is a JSON-encoded dict of the original DB
+    row.  This mirrors _read_and_load_parquet in machine.py.
+    """
+    df = pd.read_parquet(path)
+    rows = []
+    for _, row in df.iterrows():
+        payload = json.loads(row['data'])
+        payload['audit_event_type'] = row['audit_event_type']
+        payload['audit_changed_at'] = row['audit_changed_at']
+        rows.append(payload)
+    return pd.DataFrame(rows)
+
+
+def _to_dt(val):
+    """Convert a value to a naive Python datetime, or None."""
+    if val is None:
+        return None
+    if isinstance(val, pd.Timestamp):
+        if pd.isnull(val):
+            return None
+        dt = val.to_pydatetime()
+    else:
+        try:
+            dt = dateparse(str(val))
+        except Exception:
+            return None
+    return dt.replace(tzinfo=None) if dt.tzinfo is not None else dt
+
+
+def get_instance_events_from_parquet(data_dir, start=None, end=None):
+    """Read instance action events from openstack_audit parquet files and yield trace dicts.
+
+    Replicates the SQL JOIN:
+        instances AS i
+        JOIN instance_actions AS ia ON i.uuid = ia.instance_uuid
+        JOIN instance_actions_events AS iae ON ia.id = iae.action_id
+    WHERE i.user_id != 'admin' AND i.project_id != 'admin'
+    AND (optional) ia.created_at >= start AND ia.created_at <= end
+    AND iae.finish_time IS NOT NULL
+
+    Parameters
+    ----------
+    data_dir : str
+        Directory containing the three openstack_audit nova parquet files.
+    start : datetime or None
+        Optional lower bound on ia.created_at (action start time).
+    end : datetime or None
+        Optional upper bound on ia.created_at (action start time).
+
+    Yields
+    ------
+    dict
+        One dict per event row with renamed keys matching TRACE_EVENT_KEY_RENAME_MAP.
+    """
+    instances_path = os.path.join(
+        data_dir, 'openstack_audit.audit_nova_instances.parquet')
+    actions_path = os.path.join(
+        data_dir, 'openstack_audit.audit_nova_instance_actions.parquet')
+    events_path = os.path.join(
+        data_dir, 'openstack_audit.audit_nova_instance_actions_events.parquet')
+
+    LOG.info('Reading audit_nova_instances from %s', instances_path)
+    df_instances = _parse_audit_parquet(instances_path)
+
+    LOG.info('Reading audit_nova_instance_actions from %s', actions_path)
+    df_actions = _parse_audit_parquet(actions_path)
+
+    LOG.info('Reading audit_nova_instance_actions_events from %s', events_path)
+    df_events = _parse_audit_parquet(events_path)
+
+    # Each audit table may have INSERT and DELETE rows.  For instances we only
+    # want the INSERT (creation) record to get the instance metadata.
+    # For actions and events there are only INSERTs in practice, but filter
+    # defensively so we don't double-count if DELETEs ever appear.
+    if 'audit_event_type' in df_instances.columns:
+        df_instances = df_instances[df_instances['audit_event_type'] == 'INSERT']
+    if 'audit_event_type' in df_actions.columns:
+        df_actions = df_actions[df_actions['audit_event_type'] == 'INSERT']
+    if 'audit_event_type' in df_events.columns:
+        df_events = df_events[df_events['audit_event_type'] == 'INSERT']
+
+    # Drop audit metadata columns before merging
+    drop_cols = ['audit_event_type', 'audit_changed_at']
+    df_instances = df_instances.drop(columns=[c for c in drop_cols if c in df_instances.columns])
+    df_actions   = df_actions.drop(columns=[c for c in drop_cols if c in df_actions.columns])
+    df_events    = df_events.drop(columns=[c for c in drop_cols if c in df_events.columns])
+
+    # Filter out admin instances (mirrors SQL WHERE clause)
+    df_instances = df_instances[
+        (df_instances['user_id'] != 'admin') &
+        (df_instances['project_id'] != 'admin')
+    ]
+
+    # Keep only columns we need to reduce memory usage
+    instance_cols = ['uuid', 'memory_mb', 'root_gb', 'vcpus',
+                     'user_id', 'project_id', 'hostname', 'host']
+    df_instances = df_instances[[c for c in instance_cols if c in df_instances.columns]]
+
+    # Deduplicate instances by uuid — keep the first INSERT per uuid
+    df_instances = df_instances.drop_duplicates(subset=['uuid'], keep='first')
+
+    # Apply optional time filters on action created_at
+    if 'created_at' in df_actions.columns:
+        df_actions['created_at'] = pd.to_datetime(df_actions['created_at'], errors='coerce', utc=False)
+        if start is not None:
+            start_naive = start.replace(tzinfo=None) if start.tzinfo else start
+            df_actions = df_actions[df_actions['created_at'] >= start_naive]
+        if end is not None:
+            end_naive = end.replace(tzinfo=None) if end.tzinfo else end
+            df_actions = df_actions[df_actions['created_at'] <= end_naive]
+
+    action_cols = ['id', 'instance_uuid']
+    df_actions = df_actions[[c for c in action_cols if c in df_actions.columns]]
+    # Deduplicate actions by id
+    df_actions = df_actions.drop_duplicates(subset=['id'], keep='first')
+
+    event_cols = ['action_id', 'event', 'start_time', 'finish_time', 'result']
+    df_events = df_events[[c for c in event_cols if c in df_events.columns]]
+
+    # JOIN: instances <-> instance_actions on uuid = instance_uuid
+    df = pd.merge(
+        df_instances, df_actions,
+        left_on='uuid', right_on='instance_uuid',
+        how='inner',
+        suffixes=('', '_action'),
+    )
+
+    # JOIN: result <-> instance_actions_events on id = action_id
+    df = pd.merge(
+        df, df_events,
+        left_on='id', right_on='action_id',
+        how='inner',
+        suffixes=('', '_event'),
+    )
+
+    LOG.info('Total rows after join: %d', len(df))
+
+    n_records = 0
+    n_skipped = 0
+    for _, row in df.iterrows():
+        finish_time_raw = row.get('finish_time')
+        # Replicate the SQL extractor's skip of rows with no finish_time
+        if finish_time_raw is None or (isinstance(finish_time_raw, float) and pd.isnull(finish_time_raw)):
+            LOG.debug('Invalid event (no finish_time): %s', row.get('uuid'))
+            n_skipped += 1
+            continue
+        try:
+            finish_time = _to_dt(finish_time_raw)
+        except Exception:
+            n_skipped += 1
+            continue
+        if finish_time is None:
+            n_skipped += 1
+            continue
+
+        trace = {
+            'INSTANCE_UUID':        row.get('uuid'),
+            'EVENT':                row.get('event'),
+            'START_TIME':           _to_dt(row.get('start_time')),
+            'FINISH_TIME':          finish_time,
+            'RESULT':               row.get('result'),
+            'INSTANCE_NAME':        row.get('hostname'),
+            'USER_ID':              row.get('user_id'),
+            'PROJECT_ID':           row.get('project_id'),
+            'HOST_NAME (PHYSICAL)': row.get('host'),
+            # Extra instance fields preserved by the original SQL extractor
+            'memory_mb':            row.get('memory_mb'),
+            'root_gb':              row.get('root_gb'),
+            'vcpus':                row.get('vcpus'),
+        }
+        n_records += 1
+        yield trace
+
+    LOG.info('Yielded %d records (%d skipped, no finish_time)', n_records, n_skipped)

--- a/starcompactor/extractors/machine.py
+++ b/starcompactor/extractors/machine.py
@@ -9,6 +9,9 @@ import re
 import shutil
 import subprocess
 import tempfile
+import json
+import pandas as pd
+from dateutil.parser import parse as dateparse
 
 from . import mysql
 
@@ -264,5 +267,118 @@ def get_machine_event_vm(mysql_args, tmp_path, tmp_sql_file_name):
         # clean up
         db.cursor.execute('DROP DATABASE {}'.format(nova_tmp_database_name))
     
+    return machine_events, hosts
+
+def get_machine_events_from_parquet_vm(data_dir):
+    machine_events = {} # key is tuple (event_time, host_name, event)
+    hosts = set()
+    
+    # 1. Load services audit
+    services_path = os.path.join(data_dir, 'openstack_audit.audit_nova_services.parquet')
+    df_services = pd.read_parquet(services_path)
+    s_rows = []
+    for _, row in df_services.iterrows():
+        payload = json.loads(row['data'])
+        if payload.get('binary') == NOVA_COMPUTE_HOST_BINARY:
+            audit_ts = row['audit_changed_at']
+            audit_time = audit_ts.to_pydatetime() if isinstance(audit_ts, pd.Timestamp) else dateparse(str(audit_ts))
+            audit_time = audit_time.replace(tzinfo=None)
+            s_rows.append({
+                'host': payload.get('host'),
+                'service_updated_at': audit_time, 
+                'disabled': payload.get('disabled') == 1,
+            })
+    df_s = pd.DataFrame(s_rows)
+    if not df_s.empty:
+        df_s.sort_values('service_updated_at', inplace=True)
+            
+    # 2. Load compute nodes audit
+    cn_path = os.path.join(data_dir, 'openstack_audit.audit_nova_compute_nodes.parquet')
+    df_cn = pd.read_parquet(cn_path)
+    cn_rows = []
+    for _, row in df_cn.iterrows():
+        payload = json.loads(row['data'])
+        audit_ts = row['audit_changed_at']
+        audit_time = audit_ts.to_pydatetime() if isinstance(audit_ts, pd.Timestamp) else dateparse(str(audit_ts))
+        audit_time = audit_time.replace(tzinfo=None)
+        
+        host = payload.get('hypervisor_hostname') or payload.get('host')
+        
+        created_at_payload = payload.get('created_at')
+        created_at = dateparse(created_at_payload).replace(tzinfo=None) if created_at_payload else audit_time
+        
+        deleted_at_payload = payload.get('deleted_at')
+        if deleted_at_payload:
+            deleted_at = dateparse(deleted_at_payload).replace(tzinfo=None)
+        else:
+            deleted_at = audit_time if row['audit_event_type'] == 'DELETE' else None
+                
+        cn_rows.append({
+            'node_updated_at': audit_time,
+            'created_at': created_at,
+            'deleted_at': deleted_at,
+            'host': host,
+            'vcpus': payload.get('vcpus'),
+            'memory_mb': payload.get('memory_mb'),
+            'local_gb': payload.get('local_gb'),
+        })
+        
+    df_cn_parsed = pd.DataFrame(cn_rows)
+    if not df_cn_parsed.empty:
+        df_cn_parsed.sort_values('node_updated_at', inplace=True)
+        
+    # Pandas equivalent of a LEFT JOIN on host over time
+    if not df_cn_parsed.empty and not df_s.empty:
+        df_joined = pd.merge_asof(
+            df_cn_parsed, df_s,
+            left_on='node_updated_at', right_on='service_updated_at',
+            by='host', direction='backward'
+        )
+    else:
+        df_joined = df_cn_parsed
+        df_joined['disabled'] = False
+        df_joined['service_updated_at'] = None
+        
+    for _, row in df_joined.iterrows():
+        create_time = row.get('created_at')
+        node_update_time = row.get('node_updated_at')
+        delete_time = row.get('deleted_at')
+        service_update_time = row.get('service_updated_at')
+        disabled = row.get('disabled')
+        hostname = row.get('host')
+        vcpus = row.get('vcpus')
+        memory = row.get('memory_mb')
+        disk = row.get('local_gb')
+        
+        if not hostname:
+            continue
+            
+        rack = 'UNKNOWN'
+        if RACK_EXTRACTOR['hypervisor_hostname_regex'] and RACK_EXTRACTOR['rack_extract_group']:
+            m = re.search(RACK_EXTRACTOR['hypervisor_hostname_regex'], hostname)
+            if m:
+                rack = m.group(RACK_EXTRACTOR['rack_extract_group'])
+                
+        content = {
+            'rack': rack,
+            'vcpu_capability': vcpus,
+            'memory_capability_mb': memory,
+            'disk_capability_gb': disk
+        }
+            
+        # Identical to original extraction loop
+        machine_events[(create_time, hostname, 'CREATE')] = content
+        machine_events[(node_update_time, hostname, 'UPDATE')] = content
+        if pd.notnull(delete_time):
+            machine_events[(delete_time, hostname, 'DELETE')] = {}
+        if disabled:
+            if pd.notnull(service_update_time):
+                machine_events[(service_update_time, hostname, 'DISABLE')] = content
+        else:
+            if pd.notnull(service_update_time):
+                machine_events[(service_update_time, hostname, 'ENABLE')] = content
+                
+        hosts.add(hostname)
+        
     return machine_events, hosts
     

--- a/starcompactor/extractors/machine.py
+++ b/starcompactor/extractors/machine.py
@@ -381,4 +381,120 @@ def get_machine_events_from_parquet_vm(data_dir):
         hosts.add(hostname)
         
     return machine_events, hosts
-    
+
+
+def _parse_audit_timestamp(ts):
+    """Parse an audit timestamp to a naive datetime, handling both Timestamps and strings."""
+    if isinstance(ts, pd.Timestamp):
+        return ts.to_pydatetime().replace(tzinfo=None)
+    return dateparse(str(ts)).replace(tzinfo=None)
+
+
+def _read_and_load_parquet(path):
+    """Read a parquet audit file and return a DataFrame with payload fields plus
+    audit_changed_at and audit_event_type preserved from the parquet row."""
+    df = pd.read_parquet(path)
+    rows = []
+    for _, row in df.iterrows():
+        payload = json.loads(row['data'])
+        payload['audit_changed_at'] = _parse_audit_timestamp(row['audit_changed_at'])
+        payload['audit_event_type'] = row['audit_event_type']
+        rows.append(payload)
+    return pd.DataFrame(rows)
+
+
+def get_machine_events_from_parquet_baremetal(data_dir):
+    machine_events = {}  # key is tuple (event_time, node_id, event)
+    hosts = set()
+
+    nodes_path = os.path.join(data_dir, 'openstack_audit.audit_ironic_nodes.parquet')
+    blazar_hosts_path = os.path.join(data_dir, 'openstack_audit.audit_blazar_computehosts.parquet')
+    blazar_host_capabilities_path = os.path.join(data_dir, 'openstack_audit.audit_blazar_computehost_extra_capabilities.parquet')
+    blazar_capabilities_path = os.path.join(data_dir, 'openstack_audit.audit_blazar_resource_properties.parquet')
+
+    nodes = _read_and_load_parquet(nodes_path)
+    blazar_hosts = _read_and_load_parquet(blazar_hosts_path)
+    blazar_host_capabilities = _read_and_load_parquet(blazar_host_capabilities_path)
+    blazar_capabilities = _read_and_load_parquet(blazar_capabilities_path)
+
+    # Filter capabilities to only the properties we care about (mirrors the SQL WHERE clause)
+    blazar_capabilities = blazar_capabilities[blazar_capabilities['property_name'].isin(BAREMETAL_PROPERTIES)]
+
+    # Join nodes -> blazar_hosts on uuid = hypervisor_hostname
+    # Suffixes avoid collisions on shared column names (created_at, updated_at, etc.)
+    df = pd.merge(nodes, blazar_hosts,
+                  left_on='uuid', right_on='hypervisor_hostname',
+                  suffixes=('_node', '_blazar_host'))
+
+    # Join -> blazar_host_capabilities on computehost_id = blazar_hosts.id
+    # blazar_hosts.id came through as id_blazar_host after the previous merge
+    df = pd.merge(df, blazar_host_capabilities,
+                  left_on='id_blazar_host', right_on='computehost_id',
+                  suffixes=('', '_blazar_cap'))
+
+    # Join -> blazar_capabilities (resource_properties) on property_id = id
+    df = pd.merge(df, blazar_capabilities,
+                  left_on='property_id', right_on='id',
+                  suffixes=('_cap', '_resource_prop'))
+
+    # At this point the columns we need are:
+    #   create_date      -> created_at_blazar_host   (when the host was registered in Blazar)
+    #   node_id          -> uuid                      (ironic node UUID)
+    #   maintenance      -> maintenance_node           (ironic maintenance flag)
+    #   node_updated_at  -> audit_changed_at_node      (audit timestamp of the ironic node row)
+    #   cap_updated_at   -> audit_changed_at_cap       (audit timestamp of the capability row,
+    #                                                   used as the UPDATE event time)
+    #   capability_name  -> property_name              (from resource_properties)
+    #   capability_value -> capability_value            (from computehost_extra_capabilities)
+
+    # Group by node so we can collect all properties and derive per-node event times,
+    # mirroring the SQL version's node-by-node loop.
+    for node_id, group in df.groupby('uuid'):
+        # CREATE time: created_at from blazar computehosts (equivalent to SQL create_date)
+        create_date_raw = group['created_at_blazar_host'].iloc[0]
+        if pd.isnull(create_date_raw):
+            create_date = None
+        elif isinstance(create_date_raw, str):
+            create_date = dateparse(create_date_raw).replace(tzinfo=None)
+        else:
+            create_date = create_date_raw
+
+        # UPDATE time: max audit_changed_at across all capability rows for this node
+        # (audit_changed_at is already a naive datetime, set by _read_and_load_parquet)
+        # After merges the capability audit timestamp is in audit_changed_at_cap
+        cap_audit_times = group['audit_changed_at_cap'].dropna()
+        update_time = cap_audit_times.max() if not cap_audit_times.empty else create_date
+
+        # Collect property dict for CREATE / UPDATE events
+        property_collections = {
+            row['property_name']: row['capability_value']
+            for _, row in group.iterrows()
+            if row['property_name'] in BAREMETAL_PROPERTIES
+        }
+
+        # Emit CREATE event
+        if create_date is not None:
+            machine_events[(create_date, node_id, 'CREATE')] = property_collections
+
+        # Emit UPDATE event
+        if update_time is not None:
+            machine_events[(update_time, node_id, 'UPDATE')] = property_collections
+
+        # Emit DISABLE / ENABLE events, one per distinct (node_updated_at, maintenance) pair.
+        # Each ironic audit row can have its own maintenance state at its own timestamp,
+        # so we deduplicate by (audit_changed_at_node, maintenance) to avoid overwriting
+        # events that were already written with the same key.
+        for _, row in group.drop_duplicates(subset=['audit_changed_at_node', 'maintenance']).iterrows():
+            node_update_time = row['audit_changed_at_node']
+            is_maint = row['maintenance'] == 1
+
+            event_type = 'DISABLE' if is_maint else 'ENABLE'
+            maint_key = (node_update_time, node_id, event_type)
+
+            # Mirror SQL version: only write the first occurrence of a given key
+            if maint_key not in machine_events:
+                machine_events[maint_key] = {}
+            # Accumulate properties onto the event (SQL version builds the dict incrementally)
+            machine_events[maint_key][row['property_name']] = row['capability_value']
+
+    return machine_events, hosts

--- a/starcompactor/formatters/csv_formatter.py
+++ b/starcompactor/formatters/csv_formatter.py
@@ -57,5 +57,4 @@ def write(filename, traces, trace_type, instance_type):
 
         for n, trace in enumerate(traces):
             line = csv_row(trace, trace_type, instance_type)
-            LOG.info(line)
             csvwriter.writerow(line)

--- a/starcompactor/instance_event_api_dump.py
+++ b/starcompactor/instance_event_api_dump.py
@@ -19,6 +19,7 @@ from .util import pipeline
 TRACE_TYPE = 'instance'
 
 LOG = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 def main():
     config = configparser.ConfigParser()

--- a/starcompactor/instance_event_api_dump.py
+++ b/starcompactor/instance_event_api_dump.py
@@ -9,7 +9,7 @@ import sys
 import configparser
 
 from dateutil.parser import parse as dateparse
-from hammers.osapi import Auth
+import openstack
 from .extractors import http
 from .formatters import csv_formatter, jsons
 from .transforms.derived import extra_times
@@ -34,8 +34,8 @@ def main():
         help='Type of the instance. Choose vm or baremetal')
     parser.add_argument('--jsons', action='store_true',
         help='Format output as one JSON per line (defaults to CSV-style). Note that the file itself is *not* a JSON; read line-by-line and append them to an array for a proper JSON.')
-    parser.add_argument('--osrc', type=str,
-        help='RC file containing OS envvars.')
+    parser.add_argument('--os-cloud', type=str, default=None,
+        help='OpenStack cloud name from clouds.yaml to connect to.')
     parser.add_argument('--verbose', action='store_const', const=logging.INFO, dest="loglevel",
         help='Increase verbosity about the dump.')
     parser.add_argument('--debug', action='store_const', const=logging.DEBUG, dest="loglevel",
@@ -58,9 +58,9 @@ def main():
     masker_config['salt'] = args.hashed_masking_salt
     mask = Masker(**masker_config)
 
-    auth = Auth.from_env_or_args(env=True, args=args)
+    conn = openstack.connect(cloud=args.os_cloud)
 
-    traces = http.traces(auth)
+    traces = http.traces(conn)
     traces = pipeline(traces,
         functools.partial(mask_fields, trace_type=TRACE_TYPE, masker=mask),
         functools.partial(extra_times, epoch=epoch),

--- a/starcompactor/instance_event_dump.py
+++ b/starcompactor/instance_event_dump.py
@@ -78,7 +78,7 @@ def main(argv):
 
     if args.use_parquet:
         data_dir = args.parquet_data_dir
-        t = instance_extractor.get_instance_events_from_parquet(data_dir, start=start, end=end)
+        t = instance_extractor.get_instance_events_from_parquet(data_dir, start=start, end=end, instance_type=args.instance_type)
         t = pipeline(t,
                     functools.partial(trans.mask_fields, trace_type=TRACE_TYPE, masker=mask),
                     functools.partial(trans.extra_times, epoch=epoch),

--- a/starcompactor/instance_event_dump.py
+++ b/starcompactor/instance_event_dump.py
@@ -1,0 +1,116 @@
+# coding: utf-8
+import argparse
+import datetime
+import functools
+import logging
+import sys
+
+import configparser
+
+from dateutil.parser import parse as dateparse
+
+from . import transforms as trans
+from .extractors import mysql, instance as instance_extractor
+from .formatters import csv_formatter, jsons
+from .util import pipeline
+
+TRACE_TYPE = 'instance'
+
+LOG = logging.getLogger(__name__)
+
+def datetime_serializer(obj):
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    raise TypeError("don't know how to serialize object {}".format(repr(obj)))
+
+
+def main(argv):
+    config = configparser.ConfigParser()
+    config.read('starcompactor.config')
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    mysqlargs = mysql.MySqlArgs({
+        'user': 'root',
+        'password': '',
+        'host': 'localhost',
+        'port': 3306,
+    })
+    mysqlargs.inject(parser)
+    parser.add_argument('--start', type=str)
+    parser.add_argument('--end', type=str)
+    parser.add_argument('--hashed-masking-method', type=str, default='sha2-salted', choices=trans.MASKERS,
+        help='User data mask type. "sha1-raw" is legacy and not recommended as it is vulnerable to cracking. "none" is for debugging only.')
+    parser.add_argument('--hashed-masking-salt', type=str, default=None,
+        help = 'Salt of hashed masking method. Please use the same salt for machine event host name! Ignored if masking method is "none".')
+    parser.add_argument('--instance-type', type=str, default='vm', choices=['vm', 'baremetal'],
+        help='Type of the instance. Choose vm or baremetal')
+    parser.add_argument('--use-parquet', action='store_true',
+        help='Use parquet files in data/ instead of connecting to MySQL')
+    parser.add_argument('--parquet-data-dir', type=str, default=None,
+        help='Directory containing parquet files (nova.instances, nova.instance_actions, nova.instance_actions_events)')
+    parser.add_argument('--jsons', action='store_true',
+        help='Format output as one JSON per line (defaults to CSV-style)')
+    parser.add_argument('--verbose', action='store_const', const=logging.INFO, dest="loglevel",
+        help='Increase verbosity about the dump.')
+    parser.add_argument('--debug', action='store_const', const=logging.DEBUG, dest="loglevel",
+        help='Debug-level logging.')
+    parser.add_argument('output_file', type=str, help='File to dump results')
+
+    args = parser.parse_args(argv[1:])
+    mysqlargs.extract(args)
+
+    if args.loglevel is None:
+        args.loglevel = logging.WARNING
+    logging.basicConfig(level=args.loglevel)
+
+    LOG.debug('instance type: {}'.format(args.instance_type))
+
+    start = dateparse(args.start) if args.start else None
+    end = dateparse(args.end) if args.end else None
+
+    epoch = dateparse(config.get('default', 'epoch'))
+    LOG.debug('epoch time: {}'.format(epoch))
+
+    masker_config = trans.MASKERS[args.hashed_masking_method]
+    LOG.debug('using masker options {}'.format(masker_config))
+    masker_config['salt'] = args.hashed_masking_salt
+    mask = trans.Masker(**masker_config)
+
+    if args.use_parquet:
+        data_dir = args.parquet_data_dir
+        t = instance_extractor.get_instance_events_from_parquet(data_dir, start=start, end=end)
+        t = pipeline(t,
+                    functools.partial(trans.mask_fields, trace_type=TRACE_TYPE, masker=mask),
+                    functools.partial(trans.extra_times, epoch=epoch),
+                    )
+        traces = sorted(list(t), key=lambda i: i['START_TIME'] if i['START_TIME'] else datetime.datetime.min)
+    else:
+        db = mysqlargs.connect()
+        databases = config.get('default', 'nova_databases').split(',')
+
+        if args.loglevel <= logging.DEBUG:
+            n_records = 0
+            for database in databases:
+                n_records = n_records + int(list(mysql.count_instances(db, database))[0]['cnt'])
+            LOG.debug('number of instance records: {}'.format(str(n_records)))
+
+        traces = []
+        for database in databases:
+            t = mysql.traces(db, database, start=start, end=end)
+            t = pipeline(t,
+                        functools.partial(trans.mask_fields, trace_type=TRACE_TYPE, masker=mask),
+                        functools.partial(trans.extra_times, epoch=epoch),
+                        )
+            traces = traces + list(t)
+
+        traces = sorted(traces, key=lambda i: i['START_TIME'])
+
+    if args.jsons:
+        LOG.debug('writing JSONs to {}'.format(args.output_file))
+        jsons.write(args.output_file, traces, TRACE_TYPE, args.instance_type)
+    else:
+        LOG.debug('writing CSV to {}'.format(args.output_file))
+        csv_formatter.write(args.output_file, traces, TRACE_TYPE, args.instance_type)
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/starcompactor/machine_event_dump.py
+++ b/starcompactor/machine_event_dump.py
@@ -118,6 +118,8 @@ def main(argv):
         help='Type of the instance. Choose vm or baremetal')
     parser.add_argument('--use-parquet', action='store_true',
         help='Use parquet audit files in data/ instead of daily mysql dumps')
+    parser.add_argument('--parquet-data-dir', type=str, default=None,
+        help='Directory containing parquet audit files)')
     parser.add_argument('--jsons', action='store_true',
         help='Format output as one JSON per line (defaults to CSV-style)')
     parser.add_argument('--verbose', action='store_const', const=logging.INFO, dest="loglevel",
@@ -147,8 +149,11 @@ def main(argv):
     mask = trans.Masker(**masker_config)
 
     if args.use_parquet and args.instance_type == 'vm':
-        data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+        data_dir = args.parquet_data_dir
         machine_events, _ = machine.get_machine_events_from_parquet_vm(data_dir)
+    elif args.use_parquet and args.instance_type == 'baremetal':
+        data_dir = args.parquet_data_dir
+        machine_events, _ = machine.get_machine_events_from_parquet_baremetal(data_dir)
     else:
         backup_dir = config.get('backup', 'backup_dir')
         backup_files = [join(backup_dir, f) for f in listdir(backup_dir) if isfile(join(backup_dir, f)) and re.match(config.get('backup', 'backup_file_regex'), f)]

--- a/starcompactor/machine_event_dump.py
+++ b/starcompactor/machine_event_dump.py
@@ -116,6 +116,8 @@ def main(argv):
         help = 'Salt of hashed masking method (for host name). Please use the same salt for instance event host name! Ignored if host name mask type is "none".')
     parser.add_argument('--instance-type', type=str, default='vm', choices=['vm', 'baremetal'],
         help='Type of the instance. Choose vm or baremetal')
+    parser.add_argument('--use-parquet', action='store_true',
+        help='Use parquet audit files in data/ instead of daily mysql dumps')
     parser.add_argument('--jsons', action='store_true',
         help='Format output as one JSON per line (defaults to CSV-style)')
     parser.add_argument('--verbose', action='store_const', const=logging.INFO, dest="loglevel",
@@ -144,51 +146,55 @@ def main(argv):
     
     mask = trans.Masker(**masker_config)
 
-    backup_dir = config.get('backup', 'backup_dir')
-    backup_files = [join(backup_dir, f) for f in listdir(backup_dir) if isfile(join(backup_dir, f)) and re.match(config.get('backup', 'backup_file_regex'), f)]
-    backup_files.sort(key=lambda x: os.path.getmtime(x))
-        
-    machine_args = []
-    process_no = 0
-    for backup_file in backup_files:
-        arg = {'process_no': process_no,
-               'backup_file': backup_file, 
-               'mysql_args': mysqlargs.connect_kwargs, 
-               'instance_type': args.instance_type}
-        machine_args.append(arg)  
-        process_no = process_no + 1
-    
-    with contextlib.closing(multiprocessing.Pool(processes=int(math.ceil(process_no / int(config.get('multithread', 'number_of_files_per_process')))))) as pool:
-        process_results = pool.map(get_machine_event_with_packed_args, machine_args)
-    
-    machine_events = {}
-    # multiprocessing keeps the order
-    # create DELETE events
-    prev_hosts = None
-    process_no = 0
-    for result in process_results:
-        if not result or 'hosts' not in result:
-            LOG.warn('missing result from process {}'.format(str(process_no)))
+    if args.use_parquet and args.instance_type == 'vm':
+        data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+        machine_events, _ = machine.get_machine_events_from_parquet_vm(data_dir)
+    else:
+        backup_dir = config.get('backup', 'backup_dir')
+        backup_files = [join(backup_dir, f) for f in listdir(backup_dir) if isfile(join(backup_dir, f)) and re.match(config.get('backup', 'backup_file_regex'), f)]
+        backup_files.sort(key=lambda x: os.path.getmtime(x))
+            
+        machine_args = []
+        process_no = 0
+        for backup_file in backup_files:
+            arg = {'process_no': process_no,
+                   'backup_file': backup_file, 
+                   'mysql_args': mysqlargs.connect_kwargs, 
+                   'instance_type': args.instance_type}
+            machine_args.append(arg)  
             process_no = process_no + 1
-            continue
-        current_hosts = result['hosts']
-        if prev_hosts:
-            deleted_hosts = prev_hosts.difference(current_hosts)
-            for host in deleted_hosts:
-                machine_events[(result['file_time'], host, 'DELETE')] = {}
-        prev_hosts = current_hosts
-        process_no = process_no + 1
-    
-    # we need to reverse the order for "CREATE" event
-    # so that we get the contents for create events from the earliest backup file.
-    # Example:
-    # In 2015-10-09 backup and for host x, "created_at" 2015-10-09 with 48 available VCPUs.
-    # In 2017-11-01 backup and for host x, "created_at" 2015-10-09 with 40 available VCPUs.
-    # For create event of host x, we choose the content from 2015-10-09 backup.
-    process_results.reverse()
-    for result in process_results:
-        if result and 'machine_events' in result:
-            machine_events.update(result['machine_events'])
+        
+        with contextlib.closing(multiprocessing.Pool(processes=int(math.ceil(process_no / int(config.get('multithread', 'number_of_files_per_process')))))) as pool:
+            process_results = pool.map(get_machine_event_with_packed_args, machine_args)
+        
+        machine_events = {}
+        # multiprocessing keeps the order
+        # create DELETE events
+        prev_hosts = None
+        process_no = 0
+        for result in process_results:
+            if not result or 'hosts' not in result:
+                LOG.warn('missing result from process {}'.format(str(process_no)))
+                process_no = process_no + 1
+                continue
+            current_hosts = result['hosts']
+            if prev_hosts:
+                deleted_hosts = prev_hosts.difference(current_hosts)
+                for host in deleted_hosts:
+                    machine_events[(result['file_time'], host, 'DELETE')] = {}
+            prev_hosts = current_hosts
+            process_no = process_no + 1
+        
+        # we need to reverse the order for "CREATE" event
+        # so that we get the contents for create events from the earliest backup file.
+        # Example:
+        # In 2015-10-09 backup and for host x, "created_at" 2015-10-09 with 48 available VCPUs.
+        # In 2017-11-01 backup and for host x, "created_at" 2015-10-09 with 40 available VCPUs.
+        # For create event of host x, we choose the content from 2015-10-09 backup.
+        process_results.reverse()
+        for result in process_results:
+            if result and 'machine_events' in result:
+                machine_events.update(result['machine_events'])
         
     # refine machine events
     # 1. consecutive events with different timestamps but the same event type and properties is not valid; pick the earliest timestamp

--- a/starcompactor/transforms/masker.py
+++ b/starcompactor/transforms/masker.py
@@ -32,6 +32,8 @@ class Masker:
     def __init__(self, method='sha256', salt=None, truncate=None):
         if salt is None:
             self.salt = os.urandom(32)
+        elif isinstance(salt, str):
+            self.salt = salt.encode('utf-8')
         else:
             self.salt = salt
         self.method = method
@@ -40,7 +42,7 @@ class Masker:
     def __call__(self, data):
         if self.method == 'raw':
             return data[:self.truncate]
-        h = hashlib.new(self.method, self.salt.encode('utf-8'))
+        h = hashlib.new(self.method, self.salt)
         h.update(data.encode('utf-8'))
         return h.hexdigest()[:self.truncate]
 


### PR DESCRIPTION
- Updated machine and instance traces to load data from audit tables. Fairly similar to the existing sql queries, but joining pandas dataframes.
- Added a `run.sh` script which wraps everything and syncs the audit data.
- Changes to http.py don't end up working: the API just doesn't work for generating traces. Should be added to the readme.